### PR TITLE
Adjusted links to use the .org domain and HTTPS.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta content="X5tHeKjV-jMLyp4VMoUhW9PAYaOjtPslV250" name="csrf-token">
 
   <title>Privacy Policy | freeCodeCamp</title>
-  <link href="http://freecodecamp.com" rel="canonical">
+  <link href="https://www.freecodecamp.org" rel="canonical">
   <meta charset="utf-8">
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
@@ -20,7 +20,7 @@
   <meta content="freeCodeCamp" property="og:site_name">
   <meta content="on" name="twitter:widgets:csp">
   <meta content="d0bc047a482c03c24f1168004c2a216a" name="p:domain_verify">
-  <meta content="http://www.freecodecamp.com" property="og:url">
+  <meta content="https://www.freecodecamp.org" property="og:url">
   <meta content=
   "Learn to code and build projects for nonprofits. Build your full stack web development portfolio today."
   property="og:description">
@@ -37,7 +37,7 @@
   "Learn to code and build projects for nonprofits. Build your full stack web development portfolio today."
   name="description">
   <meta content="@freecodecamp" name="twitter:creator">
-  <meta content="http://www.freecodecamp.com" name="twitter:url">
+  <meta content="https://www.freecodecamp.org" name="twitter:url">
   <meta content="@freecodecamp" name="twitter:site">
   <meta content="summary_large_image" name="twitter:card">
   <meta content=
@@ -162,7 +162,7 @@
     <div class="return-to-free-code-camp">
       <ul class="nav navbar-nav navbar-right">
         <li class="hidden-xs return-to-free-code-camp wrappable">
-          <a href="https://www.freecodecamp.com">Return to freeCodeCamp.com</a>
+          <a href="https://www.freecodecamp.org">Return to freeCodeCamp.org</a>
         </li>
       </ul>
     </div>
@@ -217,12 +217,12 @@
 
 
       <p>If you have questions about deleting or correcting your personal data
-      please email us at <a href="mailto:team@freecodecamp.com">team@freecodecamp.com</a>.</p>
+      please email us at <a href="mailto:team@freecodecamp.org">team@freecodecamp.org</a>.</p>
 
 
       <p>freeCodeCamp Inc. (“<strong>freeCodeCamp</strong>”) operates several
       websites including <a href=
-      "http://freeCodeCamp.com/">freeCodeCamp.com</a>. It is freeCodeCamp’s
+      "https://www.freeCodeCamp.org/">freeCodeCamp.org</a>. It is freeCodeCamp’s
       policy to respect your privacy regarding any information we may collect
       while operating our websites.</p>
 
@@ -244,7 +244,7 @@
       <p>freeCodeCamp also collects potentially personally-identifying
       information like Internet Protocol (IP) addresses for logged in users and
       for users leaving comments on <a href=
-      "http://freeCodeCamp.com">freeCodeCamp.com</a> blogs. freeCodeCamp only
+      "https://www.freeCodeCamp.org">freeCodeCamp.org</a> blogs. freeCodeCamp only
       discloses logged in user and commenter IP addresses under the same
       circumstances that it uses and discloses personally-identifying
       information as described below, except that blog commenter IP addresses
@@ -262,7 +262,7 @@
       personally-identifying information. The amount and type of information
       that freeCodeCamp gathers depends on the nature of the interaction. For
       example, we ask visitors who create an account for tracking their
-      progress at <a href="http://freeCodeCamp.com/">freeCodeCamp.com</a> to
+      progress at <a href="https://www.freeCodeCamp.org/">freeCodeCamp.org</a> to
       provide either an email address or sign in with a social media oauth
       service like GitHub. Those who engage in transactions with freeCodeCamp –
       by placing job ads, for example – are asked to provide additional
@@ -368,7 +368,7 @@
       its Privacy Policy from time to time, and in freeCodeCamp’s sole
       discretion. freeCodeCamp encourages visitors to frequently check this
       page for any changes to its Privacy Policy. If you have a <a href=
-      "http://freeCodeCamp.com">freeCodeCamp.com</a> account, you should also
+      "https://www.freeCodeCamp.org">freeCodeCamp.org</a> account, you should also
       check your blog’s dashboard for alerts to these changes. Your continued
       use of this site after any change in this Privacy Policy will constitute
       your acceptance of such change.</p>
@@ -384,7 +384,7 @@
       <hr>
 
 
-      <p>If you have questions about this privacy policy, email us at <a href="mailto:team@freecodecamp.com">team@freecodecamp.com</a>.</p>
+      <p>If you have questions about this privacy policy, email us at <a href="mailto:team@freecodecamp.org">team@freecodecamp.org</a>.</p>
     </div>
   </div>
 </body>


### PR DESCRIPTION
This updates the links to use the freecodecamp.org domain name as opposed to the old freecodecamp.com domain name, links also use HTTPS now.